### PR TITLE
doc/make : Fix path for linux build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build: build-static
 	export GO111MODULE=on; \
 	GO_ENABLED=0 go build -a -o $(IMAGE_NAME).app cmd/main/Main.go
 #   Use bellow if you're running on linux.
-#	GO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o $(IMAGE_NAME).app cmd/Main.go
+#	GO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o $(IMAGE_NAME).app cmd/main/Main.go
 
 lint: build-static
 	golint -set_exit_status ./internal/... ./pkg/...


### PR DESCRIPTION
Issue: Error when building on linux
Cause: Small typo in path

Fix: Add path to Main.go when building on linux.
